### PR TITLE
ci: GitHub Actions workflow for automated build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,13 +55,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libgl1-mesa-dev patchelf libfuse2 dpkg-dev
-          # Try to install linuxdeployqt from apt; fall back to AppImage if unavailable
-          if ! sudo apt-get install -y linuxdeployqt; then
-            echo "linuxdeployqt not available via apt, downloading AppImage..."
-            curl -fsSL -o linuxdeployqt https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
-            chmod +x linuxdeployqt
-            sudo mv linuxdeployqt /usr/local/bin/linuxdeployqt
-          fi
+          curl -fsSL -o linuxdeployqt https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+          chmod +x linuxdeployqt
+          sudo mv linuxdeployqt /usr/local/bin/linuxdeployqt
 
       - name: Qt/qmake environment (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,211 @@
+name: Build Ditherista
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*-*-*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            qt_arch: linux_gcc_64
+          - os: macos-latest
+            qt_arch: clang_64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Qt (Linux)
+        if: runner.os == 'Linux'
+        uses: jurplel/install-qt-action@v4
+        with:
+          target: 'desktop'
+          arch: linux_gcc_64
+          archives: 'qtbase qtdeclarative qtsvg qttools'
+          setup-python: true
+          cache: true
+          add-tools-to-path: true
+          set-env: true
+
+      - name: Provision ICU 73 (Linux)
+        if: runner.os == 'Linux'
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: qt-icu
+          create-args: -c conda-forge icu=73
+          init-shell: bash
+          cache-environment: true
+          cache-downloads: true
+
+      - name: Install prerequisites (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libgl1-mesa-dev patchelf libfuse2 dpkg-dev
+          # Try to install linuxdeployqt from apt; fall back to AppImage if unavailable
+          if ! sudo apt-get install -y linuxdeployqt; then
+            echo "linuxdeployqt not available via apt, downloading AppImage..."
+            curl -fsSL -o linuxdeployqt https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+            chmod +x linuxdeployqt
+            sudo mv linuxdeployqt /usr/local/bin/linuxdeployqt
+          fi
+
+      - name: Qt/qmake environment (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          eval "$(micromamba shell hook -s bash)"
+          micromamba activate qt-icu
+          echo "QT_ROOT_DIR=$QT_ROOT_DIR"
+          export PATH="$QT_ROOT_DIR/bin:$PATH"
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$QT_ROOT_DIR/lib:$LD_LIBRARY_PATH"
+          which qmake || echo "qmake not found"
+          qmake -v || true
+          which lupdate || true
+          which lrelease || true
+        shell: bash -l {0}
+
+      - name: Build libdither (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          eval "$(micromamba shell hook -s bash)"
+          micromamba activate qt-icu
+          make -C libdither libdither
+        shell: bash -l {0}
+
+      - name: Build Ditherista (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          eval "$(micromamba shell hook -s bash)"
+          micromamba activate qt-icu
+          export PATH="$QT_ROOT_DIR/bin:$PATH"
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$QT_ROOT_DIR/lib:$LD_LIBRARY_PATH"
+          LUPDATE_BIN="$QT_ROOT_DIR/bin/lupdate"
+          LRELEASE_BIN="$QT_ROOT_DIR/bin/lrelease"
+          echo "Using Qt at $QT_ROOT_DIR"
+          echo "Using LUPDATE=$LUPDATE_BIN"
+          echo "Using LRELEASE=$LRELEASE_BIN"
+          make QMAKE=qmake LUPDATE="$LUPDATE_BIN" LRELEASE="$LRELEASE_BIN" app
+        shell: bash -l {0}
+
+      - name: Package Ditherista (.deb)
+        if: runner.os == 'Linux'
+        run: |
+          eval "$(micromamba shell hook -s bash)"
+          micromamba activate qt-icu
+          make installer
+        shell: bash -l {0}
+
+      - name: Build Ditherista (AppImage)
+        if: runner.os == 'Linux'
+        run: |
+          eval "$(micromamba shell hook -s bash)"
+          micromamba activate qt-icu
+          export PATH="$QT_ROOT_DIR/bin:$PATH"
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$QT_ROOT_DIR/lib:$LD_LIBRARY_PATH"
+          make appimage
+        shell: bash -l {0}
+
+      - name: Package Ditherista (tarball)
+        if: runner.os == 'Linux'
+        run: |
+          eval "$(micromamba shell hook -s bash)"
+          micromamba activate qt-icu
+          export PATH="$QT_ROOT_DIR/bin:$PATH"
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$QT_ROOT_DIR/lib:$LD_LIBRARY_PATH"
+          make installer_tgz_full
+        shell: bash -l {0}
+
+      - name: Set up Qt (macOS)
+        if: runner.os == 'macOS'
+        uses: jurplel/install-qt-action@v4
+        with:
+          target: 'desktop'
+          arch: ${{ matrix.qt_arch }}
+          archives: 'qtbase qtdeclarative qtsvg qttools'
+          setup-python: true
+          cache: true
+          add-tools-to-path: true
+          set-env: true
+
+      - name: Qt/qmake environment (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          echo "QT_ROOT_DIR=$QT_ROOT_DIR"
+          which qmake || where qmake
+          qmake -v
+        shell: bash
+
+
+      - name: Build libdither (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          make -C libdither libdither_universal
+        shell: bash
+
+
+      - name: Build Ditherista (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          make MAC_QT_BIN_PATH="$QT_ROOT_DIR/bin" app_universal
+        shell: bash
+
+      - name: Package Ditherista (.dmg)
+        if: runner.os == 'macOS'
+        run: |
+          make installer
+        shell: bash
+
+      - name: Package artifacts
+        id: pkg
+        run: |
+          echo "dist_path=$(pwd)/dist" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ditherista-${{ runner.os }}
+          path: ${{ steps.pkg.outputs.dist_path }}
+          if-no-files-found: warn
+          retention-days: 14
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release_artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: |
+          ls -R release_artifacts || true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          generate_release_notes: true
+          name: ${{ github.ref_name }}
+          files: |
+            release_artifacts/**/*.deb
+            release_artifacts/**/*.AppImage
+            release_artifacts/**/*_full.tar.gz
+            release_artifacts/**/*.dmg


### PR DESCRIPTION
[Successful run](https://github.com/LeviSnoot/ditherista/actions/runs/17944925132)
[Test release](https://github.com/LeviSnoot/ditherista/releases/tag/2025-09-14a-RC3)

Thought I'd contribute a GitHub Action for automated builds of Ditherista. It's not perfect and possibly a bit messy but should serve well as a starting point. Runs on new tags following the current `*-*-*` scheme. Can also be run manually if desired.

Caveats:

- No Windows build. Ran into a lot of issues attempting it and they seemed to stem from the codebase rather than being environment related. For now you can build for Windows manually and attach the binary(/ies) to the release just for Windows. Alternatively you can attempt to add it to the workflow yourself, you will probably just need to patch some things for it to work.
- The AppImage is built on Ubuntu 22.04. This was as far back as I felt comfortable going, but could probably be done on earlier versions for wider compatibility.
- I've tested the AppImage and `.deb` on a Debian 13 VM and can confirm that they work, but it appears the `src/deb_installer/DEBIAN/control` file is out of date. I haven't worked much with packaging. All I know is having the following packages installed via apt allowed the `.deb` to run without errors (it'll complain about dependency mismatch when installing but it runs): `libc6 libgcc-s1 libqt6core6t64 libqt6gui6 libqt6svg6 libqt6widgets6 libstdc++6`
- The macOS `.dmg` was tested on an old 2011 Intel iMac running Sequoia 15.6.1 with OpenCore Legacy. This is obviously not an ideal testing scenario, but it's what I have, so macOS builds may need more extensive testing from someone who's able to, especially on Apple Silicon.

Other notes:

- This builds against the latest Qt LTS as per `BUILDING.md` by omitting the `version` option from the `jurplel/install-qt-action@v4` Action. I ran into the issue of needing a specific ICU version (73) that wasn't available in Ubuntu archives, so I provision it through `micromamba`.
